### PR TITLE
correction bug affichage floor

### DIFF
--- a/core/src/fr/studiokakou/kakouquest/map/Map.java
+++ b/core/src/fr/studiokakou/kakouquest/map/Map.java
@@ -488,9 +488,6 @@ public class Map {
      * Disposes resources.
      */
     public void dispose(){
-        for (Floor f : this.floors){
-            f.texture.dispose();
-        }
         for (Wall w : this.walls){
             w.texture.dispose();
         }


### PR DESCRIPTION
Les floors ne s'affichaient plus à dès qu'on passait à un autre niveau ou à la mort du joueur.